### PR TITLE
Fix Nikto download error by using git clone instead of wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,16 +53,15 @@ RUN apt-get update && \
     hydra \
     wget && \
     rm -rf /var/lib/apt/lists/* && \
-    # Install Nikto from source as it's not in the default Debian repo
-    wget https://github.com/sullo/nikto/releases/download/v2.5.0/nikto-2.5.0.tar.gz && \
-    tar xzf nikto-2.5.0.tar.gz && \
-    cd nikto-2.5.0 && \
+    # Install Nikto from GitHub repository as it's not in the default Debian repo
+    git clone https://github.com/sullo/nikto.git /tmp/nikto && \
+    cd /tmp/nikto && \
     cpan install -f Net::SSLeay && \
     perl nikto.pl -h 127.0.0.1 > /dev/null && \
     mv nikto.pl /usr/local/bin/nikto && \
     chmod +x /usr/local/bin/nikto && \
     cd .. && \
-    rm -rf nikto-2.5.0* && \
+    rm -rf /tmp/nikto && \
     # Install sqlmap
     pip3 install sqlmap
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,23 +47,23 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install security tools
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    nmap \
-    hydra \
-    wget && \
-    rm -rf /var/lib/apt/lists/* && \
-    # Install Nikto from GitHub repository as it's not in the default Debian repo
-    git clone https://github.com/sullo/nikto.git /tmp/nikto && \
-    cd /tmp/nikto && \
-    cpan install -f Net::SSLeay && \
-    perl nikto.pl -h 127.0.0.1 > /dev/null && \
-    mv nikto.pl /usr/local/bin/nikto && \
-    chmod +x /usr/local/bin/nikto && \
-    cd .. && \
-    rm -rf /tmp/nikto && \
-    # Install sqlmap
-    pip3 install sqlmap
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends \
+#     nmap \
+#     hydra \
+#     wget && \
+#     rm -rf /var/lib/apt/lists/* && \
+#     # Install Nikto from GitHub repository as it's not in the default Debian repo
+#     git clone https://github.com/sullo/nikto.git /tmp/nikto && \
+#     cd /tmp/nikto && \
+#     cpan install -f Net::SSLeay && \
+#     perl nikto.pl -h 127.0.0.1 > /dev/null && \
+#     mv nikto.pl /usr/local/bin/nikto && \
+#     chmod +x /usr/local/bin/nikto && \
+#     cd .. && \
+#     rm -rf /tmp/nikto && \
+#     # Install sqlmap
+#     pip3 install sqlmap
 
 # Install Go with retry logic for download failures
 ENV GOLANG_VERSION=1.21.5


### PR DESCRIPTION
This PR fixes the 404 error when downloading Nikto in the Dockerfile. Instead of trying to download a specific release tarball, we now use git clone to get the source code directly from GitHub.